### PR TITLE
Fix Home Assistant tracker entity mapping

### DIFF
--- a/custom_components/movara/binary_sensor.py
+++ b/custom_components/movara/binary_sensor.py
@@ -6,7 +6,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity, latest_packet_attributes, merged_attributes
+from .entity_helpers import (
+    GPS_PACKET_IDS,
+    MovaraCoordinatorEntity,
+    has_any_attribute,
+    latest_packet_attributes,
+    latest_packet_attributes_with_keys,
+    merged_attributes,
+)
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -16,25 +23,59 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [
-                MovaraOnlineBinarySensor(coordinator, device_id),
-                MovaraIgnitionBinarySensor(coordinator, device_id),
-                MovaraGpsIgnitionBinarySensor(coordinator, device_id),
-                MovaraGpsFixBinarySensor(coordinator, device_id),
-                MovaraMovingBinarySensor(coordinator, device_id),
-                MovaraTripActiveBinarySensor(coordinator, device_id),
-                MovaraChargingBinarySensor(coordinator, device_id),
-                MovaraRelayBinarySensor(coordinator, device_id),
-                MovaraMotionMonitoringBinarySensor(coordinator, device_id),
-                MovaraDeviceActiveBinarySensor(coordinator, device_id),
-                MovaraDefenseArmedBinarySensor(coordinator, device_id),
-                MovaraGt06PowerAlarmBinarySensor(coordinator, device_id),
-                MovaraGt06LowBatteryAlarmBinarySensor(coordinator, device_id),
-                MovaraGt06SpeedAlarmBinarySensor(coordinator, device_id),
-                MovaraGt06StatusGpsBinarySensor(coordinator, device_id),
-            ],
+            lambda device: build_binary_sensor_entities(coordinator, device),
         )
     )
+
+
+def build_binary_sensor_entities(coordinator, device: dict) -> list[BinarySensorEntity]:
+    device_id = device["id"]
+    entities: list[BinarySensorEntity] = [MovaraOnlineBinarySensor(coordinator, device_id)]
+    latest_position = device.get("latest_position") or {}
+
+    if has_any_attribute(device, "ignition", "gt06_status_acc_on"):
+        entities.append(MovaraIgnitionBinarySensor(coordinator, device_id))
+
+    if latest_packet_attributes(device, *GPS_PACKET_IDS) or latest_packet_attributes_with_keys(device, "ignition"):
+        entities.append(MovaraGpsIgnitionBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gps_fix"):
+        entities.append(MovaraGpsFixBinarySensor(coordinator, device_id))
+
+    if isinstance(latest_position.get("speed"), (int, float)) or has_any_attribute(device, "is_moving"):
+        entities.append(MovaraMovingBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "ignition", "gt06_status_acc_on", "is_moving") or isinstance(latest_position.get("speed"), (int, float)):
+        entities.append(MovaraTripActiveBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "charging"):
+        entities.append(MovaraChargingBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "relay_triggered"):
+        entities.append(MovaraRelayBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "motion_warning_enabled", "gt06_sensor_alarm_enabled"):
+        entities.append(MovaraMotionMonitoringBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "device_active"):
+        entities.append(MovaraDeviceActiveBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "defense_armed", "gt06_status_defense_armed"):
+        entities.append(MovaraDefenseArmedBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_power_alarm_enabled"):
+        entities.append(MovaraGt06PowerAlarmBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_low_battery_alarm_enabled"):
+        entities.append(MovaraGt06LowBatteryAlarmBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_speed_alarm_enabled"):
+        entities.append(MovaraGt06SpeedAlarmBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_status_gps_enabled"):
+        entities.append(MovaraGt06StatusGpsBinarySensor(coordinator, device_id))
+
+    return entities
 
 
 class MovaraOnlineBinarySensor(MovaraCoordinatorEntity, BinarySensorEntity):
@@ -75,7 +116,9 @@ class MovaraGpsIgnitionBinarySensor(MovaraCoordinatorEntity, BinarySensorEntity)
 
     @property
     def is_on(self) -> bool | None:
-        attrs = latest_packet_attributes(self._device(), "gps", "location_compact", "location")
+        attrs = latest_packet_attributes(self._device(), *GPS_PACKET_IDS)
+        if not attrs:
+            attrs = latest_packet_attributes_with_keys(self._device(), "ignition")
         value = attrs.get("ignition")
         return value if isinstance(value, bool) else None
 

--- a/custom_components/movara/button.py
+++ b/custom_components/movara/button.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity
+from .entity_helpers import MovaraCoordinatorEntity, device_supports_custom_commands
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -20,7 +20,7 @@ async def async_setup_entry(
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [MovaraSendCommandButton(coordinator, device_id)],
+            lambda device: [MovaraSendCommandButton(coordinator, device["id"])] if device_supports_custom_commands(device) else [],
         )
     )
 
@@ -31,6 +31,10 @@ class MovaraSendCommandButton(MovaraCoordinatorEntity, ButtonEntity):
         self._attr_name = "Send custom command"
         self._attr_unique_id = f"movara_{self._hub_key}_{device_id}_send_custom_command"
         self._attr_icon = "mdi:send"
+
+    @property
+    def available(self) -> bool:
+        return super().available and device_supports_custom_commands(self._device())
 
     async def async_press(self) -> None:
         await self.coordinator.async_send_stored_command(self._device_id)

--- a/custom_components/movara/coordinator.py
+++ b/custom_components/movara/coordinator.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import MovaraApiClient
 from .const import DOMAIN
+from .entity_helpers import device_supports_custom_commands
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,5 +46,7 @@ class MovaraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device = next((item for item in self.data.get("devices", []) if item["id"] == device_id), None)
         if not device:
             raise ValueError(f"Movara device {device_id} not found")
+        if not device_supports_custom_commands(device):
+            raise ValueError(f"Movara device {device_id} does not support custom commands")
         await self.api.async_send_custom_command(device_id, device.get("protocol", "unknown"), command_text)
         await self.async_request_refresh()

--- a/custom_components/movara/device_tracker.py
+++ b/custom_components/movara/device_tracker.py
@@ -16,9 +16,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [MovaraDeviceTracker(coordinator, device_id)],
+            lambda device: [MovaraDeviceTracker(coordinator, device["id"])] if has_coordinates(device) else [],
         )
     )
+
+
+def has_coordinates(device: dict) -> bool:
+    position = device.get("latest_position") or {}
+    return isinstance(position.get("latitude"), (int, float)) and isinstance(position.get("longitude"), (int, float))
 
 
 class MovaraDeviceTracker(MovaraCoordinatorEntity, TrackerEntity):
@@ -40,6 +45,10 @@ class MovaraDeviceTracker(MovaraCoordinatorEntity, TrackerEntity):
     def longitude(self):
         device = self._device()
         return (device.get("latest_position") or {}).get("longitude") if device else None
+
+    @property
+    def available(self) -> bool:
+        return super().available and has_coordinates(self._device() or {})
 
     @property
     def source_type(self):

--- a/custom_components/movara/entity_helpers.py
+++ b/custom_components/movara/entity_helpers.py
@@ -6,6 +6,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
+CUSTOM_COMMAND_PROTOCOLS = {"eelink", "gt06"}
+GT06_GPS_PACKET_IDS = ("0x10", "0x12", "0x22")
+GPS_PACKET_IDS = (*GT06_GPS_PACKET_IDS, "gps", "location_compact", "location")
+
 
 def device_name(device: dict[str, Any] | None) -> str:
     if not device:
@@ -44,6 +48,23 @@ def latest_packet_attributes(device: dict[str, Any] | None, *packet_ids: str) ->
     return {}
 
 
+def latest_packet_attributes_with_keys(device: dict[str, Any] | None, *keys: str) -> dict[str, Any]:
+    if not device:
+        return {}
+    snapshots = device.get("packetAttributes")
+    if not isinstance(snapshots, list):
+        return {}
+    for snapshot in snapshots:
+        if not isinstance(snapshot, dict):
+            continue
+        attributes = snapshot.get("attributes")
+        if not isinstance(attributes, dict):
+            continue
+        if any(key in attributes for key in keys):
+            return attributes
+    return {}
+
+
 def first_attribute(device: dict[str, Any] | None, *keys: str) -> Any:
     attrs = merged_attributes(device)
     for key in keys:
@@ -52,8 +73,28 @@ def first_attribute(device: dict[str, Any] | None, *keys: str) -> Any:
     return None
 
 
-def protocol_label(device: dict[str, Any] | None) -> str:
+def device_protocol(device: dict[str, Any] | None) -> str:
     protocol = (device or {}).get("protocol")
+    if isinstance(protocol, str) and protocol:
+        return protocol
+    attrs = merged_attributes(device)
+    tracking_protocol = attrs.get("tracking_protocol")
+    if isinstance(tracking_protocol, str) and tracking_protocol:
+        return tracking_protocol
+    return "unknown"
+
+
+def device_supports_custom_commands(device: dict[str, Any] | None) -> bool:
+    return device_protocol(device) in CUSTOM_COMMAND_PROTOCOLS
+
+
+def has_any_attribute(device: dict[str, Any] | None, *keys: str) -> bool:
+    attrs = merged_attributes(device)
+    return any(key in attrs for key in keys)
+
+
+def protocol_label(device: dict[str, Any] | None) -> str:
+    protocol = device_protocol(device)
     if not protocol or protocol == "unknown":
         return "Tracker"
     return str(protocol).upper()

--- a/custom_components/movara/platform_setup.py
+++ b/custom_components/movara/platform_setup.py
@@ -7,18 +7,21 @@ from typing import Any
 def async_add_coordinator_entities(
     coordinator,
     async_add_entities,
-    factory: Callable[[str], list[Any]],
+    factory: Callable[[dict[str, Any]], list[Any]],
 ) -> Callable[[], None]:
     seen: set[str] = set()
 
     def add_missing() -> None:
         new_entities: list[Any] = []
         for device in coordinator.data.get("devices", []):
-            device_id = device["id"]
-            if device_id in seen:
-                continue
-            seen.add(device_id)
-            new_entities.extend(factory(device_id))
+            for entity in factory(device):
+                unique_id = getattr(entity, "unique_id", None) or getattr(entity, "_attr_unique_id", None)
+                if not isinstance(unique_id, str) or not unique_id:
+                    continue
+                if unique_id in seen:
+                    continue
+                seen.add(unique_id)
+                new_entities.append(entity)
         if new_entities:
             async_add_entities(new_entities)
 

--- a/custom_components/movara/sensor.py
+++ b/custom_components/movara/sensor.py
@@ -10,7 +10,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity, first_attribute, merged_attributes
+from .entity_helpers import (
+    MovaraCoordinatorEntity,
+    first_attribute,
+    has_any_attribute,
+    merged_attributes,
+)
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -21,6 +26,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "keys": ("satellites",),
         "icon": "mdi:satellite-variant",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "altitude",
@@ -29,6 +35,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "m",
         "icon": "mdi:image-filter-hdr",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "odometer",
@@ -38,6 +45,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "icon": "mdi:counter",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "transform": lambda value, key: value / 1000 if key == "gt06_mileage_raw" else value,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "battery_voltage",
@@ -46,6 +54,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "V",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "control_module_voltage",
@@ -54,6 +63,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "V",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "fuel_level",
@@ -62,6 +72,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "%",
         "icon": "mdi:gas-station",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "temperature",
@@ -70,6 +81,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "degC",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "humidity",
@@ -78,6 +90,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "%",
         "device_class": SensorDeviceClass.HUMIDITY,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "illuminance",
@@ -86,6 +99,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "lx",
         "device_class": SensorDeviceClass.ILLUMINANCE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "co2",
@@ -94,6 +108,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "ppm",
         "icon": "mdi:molecule-co2",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "rpm",
@@ -102,6 +117,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "rpm",
         "icon": "mdi:gauge",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "obd_speed",
@@ -110,6 +126,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "km/h",
         "icon": "mdi:speedometer",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "power_alarm_delay_seconds",
@@ -118,6 +135,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "s",
         "icon": "mdi:timer-outline",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "power_alarm_charge_seconds",
@@ -126,6 +144,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "s",
         "icon": "mdi:battery-clock-outline",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "speed_alarm_duration_seconds",
@@ -134,6 +153,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "s",
         "icon": "mdi:av-timer",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "speed_alarm_threshold_kmh",
@@ -142,6 +162,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "km/h",
         "icon": "mdi:speedometer-medium",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "mileage_scale",
@@ -149,6 +170,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "keys": ("gt06_mileage_scale",),
         "icon": "mdi:scale",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
 ]
 
@@ -159,30 +181,35 @@ TEXT_SENSOR_DEFINITIONS = [
         "keys": ("tracking_packet_id",),
         "icon": "mdi:identifier",
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "warning_type",
         "name": "Warning type",
         "keys": ("eelink_warning_type",),
         "icon": "mdi:alert-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "report_type",
         "name": "Report type",
         "keys": ("eelink_report_type",),
         "icon": "mdi:file-document-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "fence",
         "name": "Fence status",
         "keys": ("gt06_fence",),
         "icon": "mdi:fence",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "status_code",
         "name": "Tracker status code",
         "keys": ("gt06_status_code",),
         "icon": "mdi:information-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "firmware_version",
@@ -190,42 +217,49 @@ TEXT_SENSOR_DEFINITIONS = [
         "keys": ("gt06_firmware_version",),
         "icon": "mdi:chip",
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "timezone",
         "name": "Timezone",
         "keys": ("gt06_timezone",),
         "icon": "mdi:clock-time-four-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "center_number",
         "name": "Center number",
         "keys": ("gt06_center_number",),
         "icon": "mdi:phone-cog-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "battery_state",
         "name": "Battery state",
         "keys": ("gt06_status_battery_state",),
         "icon": "mdi:battery-heart-variant",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "gprs_link",
         "name": "GPRS link",
         "keys": ("gt06_status_gprs",),
         "icon": "mdi:wan",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "gprs2_link",
         "name": "GPRS2 link",
         "keys": ("gt06_status_gprs2",),
         "icon": "mdi:wan",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "gsm_signal_text",
         "name": "Signal quality",
         "keys": ("gt06_status_gsm_signal",),
         "icon": "mdi:signal-cellular-3",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "tracker_odometer_source",
@@ -233,6 +267,7 @@ TEXT_SENSOR_DEFINITIONS = [
         "keys": ("gt06_total_mileage_km", "gt06_mileage_raw"),
         "icon": "mdi:database-search-outline",
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "create_when_keys_present": True,
     },
 ]
 
@@ -243,18 +278,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [
-                MovaraLastSeenSensor(coordinator, device_id),
-                MovaraSpeedSensor(coordinator, device_id),
-                MovaraBatterySensor(coordinator, device_id),
-                MovaraSignalSensor(coordinator, device_id),
-                MovaraCommandStatusSensor(coordinator, device_id),
-                MovaraCommandResponseSensor(coordinator, device_id),
-                *[MovaraAttributeSensor(coordinator, device_id, definition) for definition in NUMERIC_SENSOR_DEFINITIONS],
-                *[MovaraTextAttributeSensor(coordinator, device_id, definition) for definition in TEXT_SENSOR_DEFINITIONS],
-            ],
+            lambda device: build_sensor_entities(coordinator, device),
         )
     )
+
+
+def build_sensor_entities(coordinator, device: dict) -> list[SensorEntity]:
+    device_id = device["id"]
+    entities: list[SensorEntity] = [
+        MovaraLastSeenSensor(coordinator, device_id),
+        MovaraSpeedSensor(coordinator, device_id),
+    ]
+
+    if has_any_attribute(device, "battery_percent", "battery_level"):
+        entities.append(MovaraBatterySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gsm_signal_percent", "eelink_gsm_signal_level", "gsm_signal_dbm", "gt06_status_gsm_signal"):
+        entities.append(MovaraSignalSensor(coordinator, device_id))
+
+    if device.get("latest_command"):
+        entities.extend(
+            [
+                MovaraCommandStatusSensor(coordinator, device_id),
+                MovaraCommandResponseSensor(coordinator, device_id),
+            ]
+        )
+
+    for definition in NUMERIC_SENSOR_DEFINITIONS:
+        if should_create_sensor(device, definition):
+            entities.append(MovaraAttributeSensor(coordinator, device_id, definition))
+
+    for definition in TEXT_SENSOR_DEFINITIONS:
+        if should_create_sensor(device, definition):
+            entities.append(MovaraTextAttributeSensor(coordinator, device_id, definition))
+
+    return entities
+
+
+def should_create_sensor(device: dict[str, object], definition: dict) -> bool:
+    if not definition.get("create_when_keys_present"):
+        return True
+    return has_any_attribute(device, *definition["keys"])
 
 
 class MovaraBaseSensor(MovaraCoordinatorEntity, SensorEntity):

--- a/custom_components/movara/text.py
+++ b/custom_components/movara/text.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity
+from .entity_helpers import MovaraCoordinatorEntity, device_supports_custom_commands
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -20,7 +20,7 @@ async def async_setup_entry(
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [MovaraCommandText(coordinator, device_id)],
+            lambda device: [MovaraCommandText(coordinator, device["id"])] if device_supports_custom_commands(device) else [],
         )
     )
 
@@ -34,6 +34,10 @@ class MovaraCommandText(MovaraCoordinatorEntity, TextEntity):
         self._attr_unique_id = f"movara_{self._hub_key}_{device_id}_custom_command"
         self._attr_icon = "mdi:console-line"
         self._attr_native_max = 512
+
+    @property
+    def available(self) -> bool:
+        return super().available and device_supports_custom_commands(self._device())
 
     @property
     def native_value(self) -> str:

--- a/home_assistant/custom_components/movara/binary_sensor.py
+++ b/home_assistant/custom_components/movara/binary_sensor.py
@@ -6,7 +6,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity, latest_packet_attributes, merged_attributes
+from .entity_helpers import (
+    GPS_PACKET_IDS,
+    MovaraCoordinatorEntity,
+    has_any_attribute,
+    latest_packet_attributes,
+    latest_packet_attributes_with_keys,
+    merged_attributes,
+)
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -16,25 +23,59 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [
-                MovaraOnlineBinarySensor(coordinator, device_id),
-                MovaraIgnitionBinarySensor(coordinator, device_id),
-                MovaraGpsIgnitionBinarySensor(coordinator, device_id),
-                MovaraGpsFixBinarySensor(coordinator, device_id),
-                MovaraMovingBinarySensor(coordinator, device_id),
-                MovaraTripActiveBinarySensor(coordinator, device_id),
-                MovaraChargingBinarySensor(coordinator, device_id),
-                MovaraRelayBinarySensor(coordinator, device_id),
-                MovaraMotionMonitoringBinarySensor(coordinator, device_id),
-                MovaraDeviceActiveBinarySensor(coordinator, device_id),
-                MovaraDefenseArmedBinarySensor(coordinator, device_id),
-                MovaraGt06PowerAlarmBinarySensor(coordinator, device_id),
-                MovaraGt06LowBatteryAlarmBinarySensor(coordinator, device_id),
-                MovaraGt06SpeedAlarmBinarySensor(coordinator, device_id),
-                MovaraGt06StatusGpsBinarySensor(coordinator, device_id),
-            ],
+            lambda device: build_binary_sensor_entities(coordinator, device),
         )
     )
+
+
+def build_binary_sensor_entities(coordinator, device: dict) -> list[BinarySensorEntity]:
+    device_id = device["id"]
+    entities: list[BinarySensorEntity] = [MovaraOnlineBinarySensor(coordinator, device_id)]
+    latest_position = device.get("latest_position") or {}
+
+    if has_any_attribute(device, "ignition", "gt06_status_acc_on"):
+        entities.append(MovaraIgnitionBinarySensor(coordinator, device_id))
+
+    if latest_packet_attributes(device, *GPS_PACKET_IDS) or latest_packet_attributes_with_keys(device, "ignition"):
+        entities.append(MovaraGpsIgnitionBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gps_fix"):
+        entities.append(MovaraGpsFixBinarySensor(coordinator, device_id))
+
+    if isinstance(latest_position.get("speed"), (int, float)) or has_any_attribute(device, "is_moving"):
+        entities.append(MovaraMovingBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "ignition", "gt06_status_acc_on", "is_moving") or isinstance(latest_position.get("speed"), (int, float)):
+        entities.append(MovaraTripActiveBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "charging"):
+        entities.append(MovaraChargingBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "relay_triggered"):
+        entities.append(MovaraRelayBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "motion_warning_enabled", "gt06_sensor_alarm_enabled"):
+        entities.append(MovaraMotionMonitoringBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "device_active"):
+        entities.append(MovaraDeviceActiveBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "defense_armed", "gt06_status_defense_armed"):
+        entities.append(MovaraDefenseArmedBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_power_alarm_enabled"):
+        entities.append(MovaraGt06PowerAlarmBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_low_battery_alarm_enabled"):
+        entities.append(MovaraGt06LowBatteryAlarmBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_speed_alarm_enabled"):
+        entities.append(MovaraGt06SpeedAlarmBinarySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gt06_status_gps_enabled"):
+        entities.append(MovaraGt06StatusGpsBinarySensor(coordinator, device_id))
+
+    return entities
 
 
 class MovaraOnlineBinarySensor(MovaraCoordinatorEntity, BinarySensorEntity):
@@ -75,7 +116,9 @@ class MovaraGpsIgnitionBinarySensor(MovaraCoordinatorEntity, BinarySensorEntity)
 
     @property
     def is_on(self) -> bool | None:
-        attrs = latest_packet_attributes(self._device(), "gps", "location_compact", "location")
+        attrs = latest_packet_attributes(self._device(), *GPS_PACKET_IDS)
+        if not attrs:
+            attrs = latest_packet_attributes_with_keys(self._device(), "ignition")
         value = attrs.get("ignition")
         return value if isinstance(value, bool) else None
 

--- a/home_assistant/custom_components/movara/button.py
+++ b/home_assistant/custom_components/movara/button.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity
+from .entity_helpers import MovaraCoordinatorEntity, device_supports_custom_commands
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -20,7 +20,7 @@ async def async_setup_entry(
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [MovaraSendCommandButton(coordinator, device_id)],
+            lambda device: [MovaraSendCommandButton(coordinator, device["id"])] if device_supports_custom_commands(device) else [],
         )
     )
 
@@ -31,6 +31,10 @@ class MovaraSendCommandButton(MovaraCoordinatorEntity, ButtonEntity):
         self._attr_name = "Send custom command"
         self._attr_unique_id = f"movara_{self._hub_key}_{device_id}_send_custom_command"
         self._attr_icon = "mdi:send"
+
+    @property
+    def available(self) -> bool:
+        return super().available and device_supports_custom_commands(self._device())
 
     async def async_press(self) -> None:
         await self.coordinator.async_send_stored_command(self._device_id)

--- a/home_assistant/custom_components/movara/coordinator.py
+++ b/home_assistant/custom_components/movara/coordinator.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import MovaraApiClient
 from .const import DOMAIN
+from .entity_helpers import device_supports_custom_commands
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,5 +46,7 @@ class MovaraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device = next((item for item in self.data.get("devices", []) if item["id"] == device_id), None)
         if not device:
             raise ValueError(f"Movara device {device_id} not found")
+        if not device_supports_custom_commands(device):
+            raise ValueError(f"Movara device {device_id} does not support custom commands")
         await self.api.async_send_custom_command(device_id, device.get("protocol", "unknown"), command_text)
         await self.async_request_refresh()

--- a/home_assistant/custom_components/movara/device_tracker.py
+++ b/home_assistant/custom_components/movara/device_tracker.py
@@ -16,9 +16,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [MovaraDeviceTracker(coordinator, device_id)],
+            lambda device: [MovaraDeviceTracker(coordinator, device["id"])] if has_coordinates(device) else [],
         )
     )
+
+
+def has_coordinates(device: dict) -> bool:
+    position = device.get("latest_position") or {}
+    return isinstance(position.get("latitude"), (int, float)) and isinstance(position.get("longitude"), (int, float))
 
 
 class MovaraDeviceTracker(MovaraCoordinatorEntity, TrackerEntity):
@@ -40,6 +45,10 @@ class MovaraDeviceTracker(MovaraCoordinatorEntity, TrackerEntity):
     def longitude(self):
         device = self._device()
         return (device.get("latest_position") or {}).get("longitude") if device else None
+
+    @property
+    def available(self) -> bool:
+        return super().available and has_coordinates(self._device() or {})
 
     @property
     def source_type(self):

--- a/home_assistant/custom_components/movara/entity_helpers.py
+++ b/home_assistant/custom_components/movara/entity_helpers.py
@@ -6,6 +6,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
+CUSTOM_COMMAND_PROTOCOLS = {"eelink", "gt06"}
+GT06_GPS_PACKET_IDS = ("0x10", "0x12", "0x22")
+GPS_PACKET_IDS = (*GT06_GPS_PACKET_IDS, "gps", "location_compact", "location")
+
 
 def device_name(device: dict[str, Any] | None) -> str:
     if not device:
@@ -44,6 +48,23 @@ def latest_packet_attributes(device: dict[str, Any] | None, *packet_ids: str) ->
     return {}
 
 
+def latest_packet_attributes_with_keys(device: dict[str, Any] | None, *keys: str) -> dict[str, Any]:
+    if not device:
+        return {}
+    snapshots = device.get("packetAttributes")
+    if not isinstance(snapshots, list):
+        return {}
+    for snapshot in snapshots:
+        if not isinstance(snapshot, dict):
+            continue
+        attributes = snapshot.get("attributes")
+        if not isinstance(attributes, dict):
+            continue
+        if any(key in attributes for key in keys):
+            return attributes
+    return {}
+
+
 def first_attribute(device: dict[str, Any] | None, *keys: str) -> Any:
     attrs = merged_attributes(device)
     for key in keys:
@@ -52,8 +73,28 @@ def first_attribute(device: dict[str, Any] | None, *keys: str) -> Any:
     return None
 
 
-def protocol_label(device: dict[str, Any] | None) -> str:
+def device_protocol(device: dict[str, Any] | None) -> str:
     protocol = (device or {}).get("protocol")
+    if isinstance(protocol, str) and protocol:
+        return protocol
+    attrs = merged_attributes(device)
+    tracking_protocol = attrs.get("tracking_protocol")
+    if isinstance(tracking_protocol, str) and tracking_protocol:
+        return tracking_protocol
+    return "unknown"
+
+
+def device_supports_custom_commands(device: dict[str, Any] | None) -> bool:
+    return device_protocol(device) in CUSTOM_COMMAND_PROTOCOLS
+
+
+def has_any_attribute(device: dict[str, Any] | None, *keys: str) -> bool:
+    attrs = merged_attributes(device)
+    return any(key in attrs for key in keys)
+
+
+def protocol_label(device: dict[str, Any] | None) -> str:
+    protocol = device_protocol(device)
     if not protocol or protocol == "unknown":
         return "Tracker"
     return str(protocol).upper()

--- a/home_assistant/custom_components/movara/platform_setup.py
+++ b/home_assistant/custom_components/movara/platform_setup.py
@@ -7,18 +7,21 @@ from typing import Any
 def async_add_coordinator_entities(
     coordinator,
     async_add_entities,
-    factory: Callable[[str], list[Any]],
+    factory: Callable[[dict[str, Any]], list[Any]],
 ) -> Callable[[], None]:
     seen: set[str] = set()
 
     def add_missing() -> None:
         new_entities: list[Any] = []
         for device in coordinator.data.get("devices", []):
-            device_id = device["id"]
-            if device_id in seen:
-                continue
-            seen.add(device_id)
-            new_entities.extend(factory(device_id))
+            for entity in factory(device):
+                unique_id = getattr(entity, "unique_id", None) or getattr(entity, "_attr_unique_id", None)
+                if not isinstance(unique_id, str) or not unique_id:
+                    continue
+                if unique_id in seen:
+                    continue
+                seen.add(unique_id)
+                new_entities.append(entity)
         if new_entities:
             async_add_entities(new_entities)
 

--- a/home_assistant/custom_components/movara/sensor.py
+++ b/home_assistant/custom_components/movara/sensor.py
@@ -10,7 +10,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity, first_attribute, merged_attributes
+from .entity_helpers import (
+    MovaraCoordinatorEntity,
+    first_attribute,
+    has_any_attribute,
+    merged_attributes,
+)
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -21,6 +26,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "keys": ("satellites",),
         "icon": "mdi:satellite-variant",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "altitude",
@@ -29,6 +35,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "m",
         "icon": "mdi:image-filter-hdr",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "odometer",
@@ -38,6 +45,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "icon": "mdi:counter",
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "transform": lambda value, key: value / 1000 if key == "gt06_mileage_raw" else value,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "battery_voltage",
@@ -46,6 +54,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "V",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "control_module_voltage",
@@ -54,6 +63,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "V",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "fuel_level",
@@ -62,6 +72,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "%",
         "icon": "mdi:gas-station",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "temperature",
@@ -70,6 +81,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "degC",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "humidity",
@@ -78,6 +90,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "%",
         "device_class": SensorDeviceClass.HUMIDITY,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "illuminance",
@@ -86,6 +99,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "lx",
         "device_class": SensorDeviceClass.ILLUMINANCE,
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "co2",
@@ -94,6 +108,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "ppm",
         "icon": "mdi:molecule-co2",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "rpm",
@@ -102,6 +117,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "rpm",
         "icon": "mdi:gauge",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "obd_speed",
@@ -110,6 +126,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "km/h",
         "icon": "mdi:speedometer",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "power_alarm_delay_seconds",
@@ -118,6 +135,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "s",
         "icon": "mdi:timer-outline",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "power_alarm_charge_seconds",
@@ -126,6 +144,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "s",
         "icon": "mdi:battery-clock-outline",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "speed_alarm_duration_seconds",
@@ -134,6 +153,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "s",
         "icon": "mdi:av-timer",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "speed_alarm_threshold_kmh",
@@ -142,6 +162,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "unit": "km/h",
         "icon": "mdi:speedometer-medium",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "mileage_scale",
@@ -149,6 +170,7 @@ NUMERIC_SENSOR_DEFINITIONS = [
         "keys": ("gt06_mileage_scale",),
         "icon": "mdi:scale",
         "state_class": SensorStateClass.MEASUREMENT,
+        "create_when_keys_present": True,
     },
 ]
 
@@ -159,30 +181,35 @@ TEXT_SENSOR_DEFINITIONS = [
         "keys": ("tracking_packet_id",),
         "icon": "mdi:identifier",
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "warning_type",
         "name": "Warning type",
         "keys": ("eelink_warning_type",),
         "icon": "mdi:alert-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "report_type",
         "name": "Report type",
         "keys": ("eelink_report_type",),
         "icon": "mdi:file-document-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "fence",
         "name": "Fence status",
         "keys": ("gt06_fence",),
         "icon": "mdi:fence",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "status_code",
         "name": "Tracker status code",
         "keys": ("gt06_status_code",),
         "icon": "mdi:information-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "firmware_version",
@@ -190,42 +217,49 @@ TEXT_SENSOR_DEFINITIONS = [
         "keys": ("gt06_firmware_version",),
         "icon": "mdi:chip",
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "create_when_keys_present": True,
     },
     {
         "suffix": "timezone",
         "name": "Timezone",
         "keys": ("gt06_timezone",),
         "icon": "mdi:clock-time-four-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "center_number",
         "name": "Center number",
         "keys": ("gt06_center_number",),
         "icon": "mdi:phone-cog-outline",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "battery_state",
         "name": "Battery state",
         "keys": ("gt06_status_battery_state",),
         "icon": "mdi:battery-heart-variant",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "gprs_link",
         "name": "GPRS link",
         "keys": ("gt06_status_gprs",),
         "icon": "mdi:wan",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "gprs2_link",
         "name": "GPRS2 link",
         "keys": ("gt06_status_gprs2",),
         "icon": "mdi:wan",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "gsm_signal_text",
         "name": "Signal quality",
         "keys": ("gt06_status_gsm_signal",),
         "icon": "mdi:signal-cellular-3",
+        "create_when_keys_present": True,
     },
     {
         "suffix": "tracker_odometer_source",
@@ -233,6 +267,7 @@ TEXT_SENSOR_DEFINITIONS = [
         "keys": ("gt06_total_mileage_km", "gt06_mileage_raw"),
         "icon": "mdi:database-search-outline",
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "create_when_keys_present": True,
     },
 ]
 
@@ -243,18 +278,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [
-                MovaraLastSeenSensor(coordinator, device_id),
-                MovaraSpeedSensor(coordinator, device_id),
-                MovaraBatterySensor(coordinator, device_id),
-                MovaraSignalSensor(coordinator, device_id),
-                MovaraCommandStatusSensor(coordinator, device_id),
-                MovaraCommandResponseSensor(coordinator, device_id),
-                *[MovaraAttributeSensor(coordinator, device_id, definition) for definition in NUMERIC_SENSOR_DEFINITIONS],
-                *[MovaraTextAttributeSensor(coordinator, device_id, definition) for definition in TEXT_SENSOR_DEFINITIONS],
-            ],
+            lambda device: build_sensor_entities(coordinator, device),
         )
     )
+
+
+def build_sensor_entities(coordinator, device: dict) -> list[SensorEntity]:
+    device_id = device["id"]
+    entities: list[SensorEntity] = [
+        MovaraLastSeenSensor(coordinator, device_id),
+        MovaraSpeedSensor(coordinator, device_id),
+    ]
+
+    if has_any_attribute(device, "battery_percent", "battery_level"):
+        entities.append(MovaraBatterySensor(coordinator, device_id))
+
+    if has_any_attribute(device, "gsm_signal_percent", "eelink_gsm_signal_level", "gsm_signal_dbm", "gt06_status_gsm_signal"):
+        entities.append(MovaraSignalSensor(coordinator, device_id))
+
+    if device.get("latest_command"):
+        entities.extend(
+            [
+                MovaraCommandStatusSensor(coordinator, device_id),
+                MovaraCommandResponseSensor(coordinator, device_id),
+            ]
+        )
+
+    for definition in NUMERIC_SENSOR_DEFINITIONS:
+        if should_create_sensor(device, definition):
+            entities.append(MovaraAttributeSensor(coordinator, device_id, definition))
+
+    for definition in TEXT_SENSOR_DEFINITIONS:
+        if should_create_sensor(device, definition):
+            entities.append(MovaraTextAttributeSensor(coordinator, device_id, definition))
+
+    return entities
+
+
+def should_create_sensor(device: dict[str, object], definition: dict) -> bool:
+    if not definition.get("create_when_keys_present"):
+        return True
+    return has_any_attribute(device, *definition["keys"])
 
 
 class MovaraBaseSensor(MovaraCoordinatorEntity, SensorEntity):

--- a/home_assistant/custom_components/movara/text.py
+++ b/home_assistant/custom_components/movara/text.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity_helpers import MovaraCoordinatorEntity
+from .entity_helpers import MovaraCoordinatorEntity, device_supports_custom_commands
 from .platform_setup import async_add_coordinator_entities
 
 
@@ -20,7 +20,7 @@ async def async_setup_entry(
         async_add_coordinator_entities(
             coordinator,
             async_add_entities,
-            lambda device_id: [MovaraCommandText(coordinator, device_id)],
+            lambda device: [MovaraCommandText(coordinator, device["id"])] if device_supports_custom_commands(device) else [],
         )
     )
 
@@ -34,6 +34,10 @@ class MovaraCommandText(MovaraCoordinatorEntity, TextEntity):
         self._attr_unique_id = f"movara_{self._hub_key}_{device_id}_custom_command"
         self._attr_icon = "mdi:console-line"
         self._attr_native_max = 512
+
+    @property
+    def available(self) -> bool:
+        return super().available and device_supports_custom_commands(self._device())
 
     @property
     def native_value(self) -> str:


### PR DESCRIPTION
Makes Movara Home Assistant entities capability-aware so unsupported sensors and controls stay hidden until a tracker actually provides data, fixes GT06 GPS ignition packet lookups, and allows new entities to appear after later telemetry or command responses.

Keeps the root and development integration copies in sync and blocks custom commands for unsupported protocols.